### PR TITLE
Scripts

### DIFF
--- a/scripts/CREDITS.txt
+++ b/scripts/CREDITS.txt
@@ -1,0 +1,7 @@
+--------------------------------------------
+BANNERS
+--------------------------------------------
+Tool: http://www.patorjk.com/software/taag/
+Author: Patrick Gillespie
+Font: Efti Wall
+--------------------------------------------

--- a/scripts/compare-haskell-snippets.sh
+++ b/scripts/compare-haskell-snippets.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo ""
+echo "    ,,,,,            .|||.          -  _ ,  -   "
+echo "   /(o o)\           (o o)         -  (o)o)  -  "
+echo "ooO--(_)--Ooo----ooO--(_)--Ooo-----ooO'(_)--Ooo-"
+echo ""
+echo "Comparing Haskell snippets for Category Theory for Programmers"
+
+cd $(dirname $0)
+
+if [ ! -d ../../milewski-ctfp-pdf ]; then
+    echo -e "\nPlease, download milewski-ctfp-pdf repository to compare."
+    echo "Place it in the parent directory of this workspace:"
+    echo -e "\n> ls"
+    echo "Category-Theory-for-Programmers.kt"
+    echo "milewski-ctfp-pdf"
+    echo -e "\nTo download it: git clone git@github.com:hmemcpy/milewski-ctfp-pdf.git"
+    exit 1
+fi
+
+for directory in ../../milewski-ctfp-pdf/src/content/*; do
+    if [ ! -d $directory ]; then
+        continue
+    fi
+    DIRECTORY_NAME=$(basename $directory)
+    if [ -d $directory/code/haskell/ ]; then
+        echo -e "\n***********************************************************************"
+        echo -e "Comparing section $DIRECTORY_NAME\n"
+        if [ -d ../src/content/$DIRECTORY_NAME/code/haskell/ ]; then
+            diff -rEZbwB $directory/code/haskell/ ../src/content/$DIRECTORY_NAME/code/haskell/
+        else
+            echo ">>> Missing section!"
+        fi
+    fi
+done

--- a/scripts/create-initial-files-for-sections.sh
+++ b/scripts/create-initial-files-for-sections.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+function showBanner()
+{
+    echo ""
+    echo "                    .      .            _                _                        "
+    echo "    ,,,,,         .  .:::.            _|_|_            _|_|_          -  _ ,  -   "
+    echo "   /(o o)\          :(o o):  .        (o o)            (o o)         -  (o)o)  -  "
+    echo "ooO--(_)--Ooo----ooO--(_)--Ooo----ooO--(_)--Ooo----ooO--(_)--Ooo-----ooO'(_)--Ooo-"
+    echo ""
+    echo "Create initial files for sections in Category Theory for Programmers "
+}
+
+function checkDirectories()
+{
+    if [ ! -d ../../milewski-ctfp-pdf ]; then
+        echo -e "\nPlease, download the milewski-ctfp-pdf repository"
+        echo "in the parent directory of this workspace:"
+        echo -e "\n> ls"
+        echo "Category-Theory-for-Programmers.kt"
+        echo "milewski-ctfp-pdf"
+        echo -e "\nTo download it: git clone git@github.com:hmemcpy/milewski-ctfp-pdf.git"
+        exit 1
+    fi
+}
+
+function contentForFile() {
+    echo '```Haskell'
+    cat $1
+    echo '```'
+    echo '```kotlin'
+    echo ''
+    echo '```'
+    echo '................'
+}
+
+function createInitialFiles()
+{
+    for directory in ../../milewski-ctfp-pdf/src/content/*; do
+        echo -n "."
+        if [ ! -d $directory ]; then
+            continue
+        fi
+        DIRECTORY_NAME=$(basename $directory)
+        if [ -d $directory/code/haskell/ ]; then
+            for file in $directory/code/haskell/*; do
+                contentForFile $file >> ../src/main/ank/drafts/${DIRECTORY_NAME}.md
+            done
+        fi
+    done
+}
+
+showBanner
+cd $(dirname $0)
+mkdir -p ../src/main/ank/drafts/
+rm -f ../src/main/ank/drafts/*.md
+checkDirectories
+createInitialFiles
+echo -e "\n\nFinished!!\nLook at: src/main/ank/drafts/"

--- a/scripts/extract-snippets-for-book.sh
+++ b/scripts/extract-snippets-for-book.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+HASKELL="haskell"
+KOTLIN="kotlin"
+
+function showBanner()
+{
+    echo ""
+    echo "       |*|                                _              ( ( (      "
+    echo "      _|_|_          -  _ ,  -          _|_|_          '. ___ .'    "
+    echo "      (o o)         -  (o)o)  -         (o o)         '  (> <) '    "
+    echo "  ooO--(_)--Ooo-----ooO'(_)--Ooo----ooO--(_)--Ooo----ooO--(_)--Ooo- "
+    echo ""
+    echo -n "Extracting snippets for Category Theory for Programmers "
+}
+
+function extensionFromLanguage()
+{
+    if [[ $1 = $HASKELL ]]; then
+        echo "hs"
+        return 0
+    fi
+    if [[ $1 = $KOTLIN ]]; then
+        echo "kt"
+        return 0
+    fi
+    return 1
+}
+
+function sectionNameFromFile()
+{
+    BASENAME=$(basename $1)
+    echo $BASENAME | cut -d- -f1
+}
+
+function fixFilesWhenJoiningParts()
+{
+    for file in ../src/main/ank/*.md; do
+        echo -n "."
+        
+        SECTION=$(sectionNameFromFile $file)
+        FILES_NUMBER=$(ls ../src/main/ank/${SECTION}-* | wc -l)
+    
+        if [ $FILES_NUMBER -gt 1 ]; then
+            cat ../src/main/ank/${SECTION}-* > ../src/main/ank/new-file.md
+            rm ../src/main/ank/${SECTION}-*
+            mv ../src/main/ank/new-file.md ../src/main/ank/${SECTION}-new-file-from-joininig-parts.md
+        fi
+    done
+}
+
+function extractSnippets()
+{
+    for file in ../src/main/ank/*.md; do
+        echo -n "."
+    
+        SECTION=$(sectionNameFromFile $file)
+    
+        mkdir -p ../src/content/$SECTION/code/$KOTLIN/
+        mkdir -p ../src/content/$SECTION/code/$HASKELL/
+    
+        LANGUAGE=""
+        SEPARATORS_NUMBER=0
+        SNIPPED_NUMBER=0
+        while read line; do
+            if [[ $line = ..* ]]; then
+                continue
+            fi
+            if [[ $line = \`\`* ]]; then
+                SEPARATORS_NUMBER=$(($SEPARATORS_NUMBER + 1))
+                if [ $(($SEPARATORS_NUMBER % 2)) -eq 0 ]; then
+                    continue
+                fi
+                if [ $(($SEPARATORS_NUMBER % 4)) -eq 1 ]; then
+                    LANGUAGE=$HASKELL
+                    SNIPPED_NUMBER=$(($SNIPPED_NUMBER + 1))
+                    continue
+                else
+                    LANGUAGE=$KOTLIN
+                    continue
+                fi
+            fi
+            echo "$line" >> ../src/content/$SECTION/code/$LANGUAGE/snippet$(printf "%02d" $SNIPPED_NUMBER).$(extensionFromLanguage $LANGUAGE)
+        done < $file
+    done
+}
+
+showBanner
+cd $(dirname $0)
+rm -rf ../src/content/*
+fixFilesWhenJoiningParts
+extractSnippets
+echo -e "\n\nFinished!!\nLook at: src/content/"


### PR DESCRIPTION
I was going for a walk through this territory and I couldn't wait for trying to help with #29 :sweat_smile: 

Initially I only created one script for extracting the snippets but then I thought about other two scripts.

Scripts:

* Extract snippets for book (included Haskell because of the following script)
```
src/content/
├── 1.1
│   └── code
│       ├── haskell
│       │   ├── snippet01.hs
│       │   ├── snippet02.hs
│       │   ├── snippet03.hs
│       │   ├── snippet04.hs
│       │   ├── snippet05.hs
│       │   ├── snippet06.hs
│       │   └── snippet07.hs
│       └── kotlin
│           ├── snippet01.kt
│           ├── snippet02.kt
...
```
* Create initial files for sections to help contributors:
```
src/main/ank/drafts/
├── 1.10.md
├── 1.1.md
├── 1.2.md
├── 1.3.md
├── 1.4.md
├── 1.5.md
├── 1.6.md
```
* Compare Haskell snippets with the current book to check contributions:
```
...
***********************************************************************
Comparing section 1.1

Only in ../src/content/1.1/code/haskell/: snippet07.hs

***********************************************************************
...
```

Some things that I observed:

* There are absolutely correct sections: `1.2`, `1.3`, `2.1`
* `1.7` includes the translation for `C++` code which is not considered

Maybe it could be interesting to upload the drafts generated by `scripts/create-initial-files-for-sections.sh` for the missing sections to avoid mistakes (it's only necessary to write the translation in Kotlin). They are also useful for the current sections to compare them: _is Kotlin code the only difference?_