### PR TITLE
Add extra checks with GitHub actions

### DIFF
--- a/.github/workflows/control-tasks.yml
+++ b/.github/workflows/control-tasks.yml
@@ -1,0 +1,43 @@
+name: ControlTasks
+
+on: [push]
+
+jobs:
+  snippets-inspection:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Extract Haskell and Kotlin snippets
+      run: /bin/bash scripts/extract-snippets-for-book.sh
+    - name: Compare Haskell snippets
+      run: /bin/bash scripts/compare-haskell-snippets.sh
+
+  kotlin-edition:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Download repository for Kotlin Edition book
+      run: git clone --single-branch --branch kotlin-edition https://github.com/rachelcarmena/milewski-ctfp-pdf.git
+    - name: Extract Haskell and Kotlin snippets
+      run: /bin/bash scripts/extract-snippets-for-book.sh
+    - name: Build Kotling Edition
+      run: |
+        cd milewski-ctfp-pdf
+        export NIX_CURL_FLAGS=-sS
+        wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.0.4/install
+        sh /tmp/nix-install
+        . ~/.nix-profile/etc/profile.d/nix.sh
+        nix-env --version
+        nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'
+        nix-shell --pure --command 'cd src; make kotlin' || echo "Skipping the failures for now..."
+    - name: Show PDF files
+      run: |
+        echo "INFO:"
+        echo -e "\tOK = PDF file in 'milewski-ctfp-pdf/out' directory"
+        echo -e "\tFAILURE = PDF file in 'milewski-ctfp-pdf/src' directory"
+        echo "PDF files:"
+        find ./milewski-ctfp-pdf -name "*.pdf"

--- a/scripts/compare-haskell-snippets.sh
+++ b/scripts/compare-haskell-snippets.sh
@@ -5,32 +5,41 @@ echo "    ,,,,,            .|||.          -  _ ,  -   "
 echo "   /(o o)\           (o o)         -  (o)o)  -  "
 echo "ooO--(_)--Ooo----ooO--(_)--Ooo-----ooO'(_)--Ooo-"
 echo ""
-echo "Comparing Haskell snippets for Category Theory for Programmers"
+echo -e "Comparing Haskell snippets for Category Theory for Programmers\n"
 
 cd $(dirname $0)
 
-if [ ! -d ../../milewski-ctfp-pdf ]; then
-    echo -e "\nPlease, download milewski-ctfp-pdf repository to compare."
-    echo "Place it in the parent directory of this workspace:"
-    echo -e "\n> ls"
-    echo "Category-Theory-for-Programmers.kt"
-    echo "milewski-ctfp-pdf"
-    echo -e "\nTo download it: git clone git@github.com:hmemcpy/milewski-ctfp-pdf.git"
-    exit 1
+if [ ! -d ../milewski-ctfp-pdf ]; then
+    echo "Downloading repository for the book..."
+    git clone https://github.com/hmemcpy/milewski-ctfp-pdf.git ../milewski-ctfp-pdf 
 fi
 
-for directory in ../../milewski-ctfp-pdf/src/content/*; do
+rm -rf /tmp/kotlin-edition*
+for directory in ../milewski-ctfp-pdf/src/content/*; do
     if [ ! -d $directory ]; then
         continue
     fi
     DIRECTORY_NAME=$(basename $directory)
     if [ -d $directory/code/haskell/ ]; then
-        echo -e "\n***********************************************************************"
-        echo -e "Comparing section $DIRECTORY_NAME\n"
         if [ -d ../src/content/$DIRECTORY_NAME/code/haskell/ ]; then
-            diff -rEZbwB $directory/code/haskell/ ../src/content/$DIRECTORY_NAME/code/haskell/
+            echo -e "\n***********************************************************************" > /tmp/kotlin-edition-single-diff.log
+            echo " Section: $DIRECTORY_NAME" >> /tmp/kotlin-edition-single-diff.log
+            echo -e "***********************************************************************\n" >> /tmp/kotlin-edition-single-diff.log
+            diff -rEZbwB $directory/code/haskell/ ../src/content/$DIRECTORY_NAME/code/haskell/ >> /tmp/kotlin-edition-single-diff.log \
+                && echo -e "\t$DIRECTORY_NAME" >> /tmp/kotlin-edition-ok.log \
+                || ( echo -e "\t$DIRECTORY_NAME" >> /tmp/kotlin-edition-error.log; \
+                     cat /tmp/kotlin-edition-single-diff.log >> /tmp/kotlin-edition-diff.log )
         else
-            echo ">>> Missing section!"
+            echo -e "\t$DIRECTORY_NAME" >> /tmp/kotlin-edition-missing.log
         fi
     fi
 done
+
+echo "OK:"
+cat /tmp/kotlin-edition-ok.log
+echo -e "\nMISSING:"
+cat /tmp/kotlin-edition-missing.log
+echo -e "\nERRORS:"
+cat /tmp/kotlin-edition-error.log
+echo -e "\nDIFFERENCES:"
+cat /tmp/kotlin-edition-diff.log

--- a/scripts/create-initial-files-for-sections.sh
+++ b/scripts/create-initial-files-for-sections.sh
@@ -13,14 +13,9 @@ function showBanner()
 
 function checkDirectories()
 {
-    if [ ! -d ../../milewski-ctfp-pdf ]; then
-        echo -e "\nPlease, download the milewski-ctfp-pdf repository"
-        echo "in the parent directory of this workspace:"
-        echo -e "\n> ls"
-        echo "Category-Theory-for-Programmers.kt"
-        echo "milewski-ctfp-pdf"
-        echo -e "\nTo download it: git clone git@github.com:hmemcpy/milewski-ctfp-pdf.git"
-        exit 1
+    if [ ! -d ../milewski-ctfp-pdf ]; then
+        echo "Downloading repository for the book..."
+        git clone https://github.com/hmemcpy/milewski-ctfp-pdf.git ../milewski-ctfp-pdf
     fi
 }
 
@@ -47,7 +42,7 @@ function contentForScalaFile() {
 
 function createInitialFiles()
 {
-    for directoryPath in ../../milewski-ctfp-pdf/src/content/*; do
+    for directoryPath in ../milewski-ctfp-pdf/src/content/*; do
         echo -n "."
         if [ ! -d $directoryPath ]; then
             continue

--- a/scripts/extract-snippets-for-book.sh
+++ b/scripts/extract-snippets-for-book.sh
@@ -14,6 +14,14 @@ function showBanner()
     echo -n "Extracting snippets for Category Theory for Programmers "
 }
 
+function checkDirectories()
+{
+    if [ ! -d ../milewski-ctfp-pdf ]; then
+        echo "Downloading repository for the book..."
+        git clone https://github.com/hmemcpy/milewski-ctfp-pdf.git ../milewski-ctfp-pdf
+    fi
+}
+
 function extensionFromLanguage()
 {
     if [[ $1 = $HASKELL ]]; then
@@ -56,12 +64,8 @@ function extractSnippets()
     
         SECTION=$(sectionNameFromFile $file)
     
-        mkdir -p ../src/content/$SECTION/code/$KOTLIN/
+        mkdir -p ../milewski-ctfp-pdf/src/content/$SECTION/code/$KOTLIN/
         mkdir -p ../src/content/$SECTION/code/$HASKELL/
-        # For the real book:
-        # mkdir -p "../../milewski-ctfp-pdf/src/content/$SECTION/code/$KOTLIN"
-        # rm -f ../../milewski-ctfp-pdf/src/content/$SECTION/code/$HASKELL/snippet*
-        # rm -f ../../milewski-ctfp-pdf/src/content/$SECTION/code/$KOTLIN/snippet*
     
         LANGUAGE=""
         SEPARATORS_NUMBER=0
@@ -84,16 +88,15 @@ function extractSnippets()
                     continue
                 fi
             fi
-            echo "$line" >> ../src/content/$SECTION/code/$LANGUAGE/snippet$(printf "%02d" $SNIPPED_NUMBER).$(extensionFromLanguage $LANGUAGE)
-            # For the real book:
-            # echo "$line" >> "../../milewski-ctfp-pdf/src/content/$SECTION/code/$LANGUAGE/snippet$(printf "%02d" $SNIPPED_NUMBER).$(extensionFromLanguage $LANGUAGE)"
+            echo "$line" >> "../$(if [[ $LANGUAGE == $KOTLIN ]]; then echo 'milewski-ctfp-pdf/'; fi)src/content/$SECTION/code/$LANGUAGE/snippet$(printf "%02d" $SNIPPED_NUMBER).$(extensionFromLanguage $LANGUAGE)"
         done < $file
     done
 }
 
 showBanner
 cd $(dirname $0)
-rm -rf ../src/content/*
+checkDirectories
+rm -rf ../src/content/* ../milewski-ctfp-pdf/src/content/**/code/$KOTLIN
 fixFilesWhenJoiningParts
 extractSnippets
-echo -e "\n\nFinished!!\nLook at: src/content/"
+echo -e "\n\nFinished!!\nLook at: milewski-ctfp-pdf/src/content/**/code/$KOTLIN"


### PR DESCRIPTION
### Sumary

This PR includes:

* Small fixes in `scripts\*.sh`
* A **new** file `.github/workflows/control-tasks.yml` to add **extra** checks with **GitHub actions**

### Extra checks

The extra checks are added **together** the current Travis tasks.

As @i-walker suggested me, those **extra** checks don't make the build fail **for now**, until everything is OK (there are still failures with sections `1.7`, `1.10` and `2.2` which are pending to fix).

The **extra** checks are 2 independent and parallel jobs:

* `snippets-inspection`: it extracts the Haskell and Kotlin snippets and compares the Haskell snippets with the current snippets in [the repository for the book](https://github.com/hmemcpy/milewski-ctfp-pdf.git)
* `kotlin-edition`: it extracts the snippets and downloads [this WIP branch for the book](https://github.com/rachelcarmena/milewski-ctfp-pdf/tree/kotlin-edition) to try to generate the book

### An example

See the checks for this pull request.

### Some screenshots

![extract](https://user-images.githubusercontent.com/22792183/64129605-65168b00-cdbd-11e9-94c8-58f3387b8a51.png)
![compare](https://user-images.githubusercontent.com/22792183/64129607-66e04e80-cdbd-11e9-8278-c1c6a4d19d7f.png)



### Note

I sent a PDF file to @i-walker until section 1.6.
Let me know if you want to see it.