### PR TITLE
Fix: section 1.10

### DIFF
--- a/src/main/ank/1.10-natural-transformations.md
+++ b/src/main/ank/1.10-natural-transformations.md
@@ -1,68 +1,26 @@
 ```Haskell
-F f :: F a -> F b
-```
-```kotlin
-fun <A, B, F> (Kind<F, (A) -> B>).(): (Kind<F, A>) -> Kind<F, B> 
-```
-................
-```Haskell
-G f :: G a -> G b
-```
-```kotlin
-fun <A, B, G> (Kind<G, (A) -> B>).(): (Kind<G, A>) -> Kind<G, B> 
-```
-................
-```Haskell
-aA :: F a -> F b
-```
-```kotlin
-fun <A, B, F> aA(): (Kind<F, A>) -> Kind<F, B>
-```
-................
-```Haskell
-aB :: G a -> G b
-```
-```kotlin
-fun <A, B, G> aB(): (Kind<G, A>) -> Kind<G, B> 
-```
-................
-```Haskell
-􏰃􏰓􏰠􏰟alpha :: F a -> G a
-```
-```kotlin
-fun<A, F, G> alpha(): (Kind<F, A>) -> Kind<G, A>
-```
-................
-```cpp
-template<class A> G<A> alpha(F<A>):
+alpha :: forall a . F a -> G a
 ```
 ```kotlin
 fun<A, F, G> alpha(): (Kind<F, A>) -> Kind<G, A>
 ```
 ................
 ```Haskell
-􏰃􏰓􏰠􏰟alpha :: F a -> G a
+alpha :: F a -> G a
 ```
 ```kotlin
 fun<A, F, G> alpha(): (Kind<F, A>) -> Kind<G, A>
 ```
 ................
 ```Haskell
-fmapG f . alphaA = alphaB . fmapF f
+alpha :: F a -> G a
 ```
 ```kotlin
-mapG(f) compose alphaA == alphaB compose mapF(f)
+fun<A, F, G> alpha(): (Kind<F, A>) -> Kind<G, A>
 ```
 ................
 ```Haskell
-fmap f . alpha = alpha . fmap f
-```
-```kotlin
-map(f) compose alpha == alpha compose map(f) 
-```
-................
-```Haskell
-safeHead :: [a] -> Const Int a
+safeHead :: [a] -> Maybe a
 safeHead [] = Nothing
 safeHead (x:xs) = Just x
 ```
@@ -115,7 +73,7 @@ safeHead(listOf(x).map(f)) == safeHead(listOf() + f(x)) == Some(f(x))
 ................
 ```Haskell
 fmap f [] = []
-􏰦􏰄􏰇􏰫fmap f (x:xs) = f x : fmap f xs
+fmap f (x:xs) = f x : fmap f xs
 ```
 ```kotlin:ank:playground // is it arrow idiomatic ?
 tailrec fun <A, B> List<A>.map(f: (A) -> B, acc: List<B> = listOf()): List<B> =
@@ -140,7 +98,7 @@ sealed class Option<out A> : OptionOf<A> {
 ```Haskell
 length :: [a] -> Const Int a
 length [] = Const 0
-length (x:xs) = Const (1 + Const (length xs))
+length (x:xs) = Const (1 + unConst (length xs))
 ```
 ```kotlin:ank:playground
 import arrow.typeclasses.Const
@@ -177,6 +135,7 @@ fun <A> length(l: List<A>): Int = l.size
 ................
 ```Haskell
 scam :: Const Int a -> Maybe a
+scam (Const x) = Nothing
 ```
 ```kotlin
 val scam: (Const<Int, A>) -> Option<A> =
@@ -192,7 +151,7 @@ typealias Reader<D, A> = Kleisli<ForId, D, A>
 ................
 ```Haskell
 instance Functor (Reader e) where 
-  fmap f (Reader g) = Reader (\x -> f (g x)
+  fmap f (Reader g) = Reader (\x -> f (g x))
 ```
 ```kotlin
 fun <D, A> Reader(run: (D) -> A): Reader<D, A> = Kleisli(run.andThen { Id(it) })
@@ -289,3 +248,4 @@ a -> a
 ```kotlin
 ((A) -> A) -> Kind<F, A>
 ```
+................


### PR DESCRIPTION
### :warning: 
This is a **draft** PR
Please, I have a doubt and I need your help to finish it.

### :checkered_flag: 

All the checks for `1.10` are OK with this PR.

### :memo:

All the changes in this PR will be avoided with the use of the files in `drafts` directory for the next contributions:

* Sorry, `C++` code wasn't extracted for translation. Just `Haskell` code. So, this PR removes all the `C++` code and the corresponding translations. I feel your pain...
* Some snippets have been removed. See more reasons in [this closed issue](https://github.com/hmemcpy/milewski-ctfp-pdf/issues/206). I feel your pain again...

### :sos:  

I need your help with this point.

When fixing this Haskell code:

```
length :: [a] -> Const Int a
length [] = Const 0
length (x:xs) = Const (1 + unConst (length xs))
```

I tried to fix the corresponding translation with the use of `unConst` which is defined later:

```
import arrow.typeclasses.Const
import arrow.typeclasses.fix
import arrow.core.extensions.const.semigroup.semigroup
import arrow.core.extensions.semigroup

tailrec fun <A> List<A>.length(acc: Const<Int, A> = Const.just(0)): Const<Int, Any?> =
  when (isEmpty()) {
    true -> acc
    false -> drop(1).length(
      Const.semigroup<Int, A>(Int.semigroup())
        .run { acc + Const.just<Int, A>(1) }.fix()
    )
  }
```

```
fun <A, T> Const<A, T>.unConst() = value()
```

However, I cannot find the way to use 'unConst' with the tail recursive function. `unConst` provides an integer and the accumulator has the type of `Const`.