### PR TITLE
Fix: section 2.2

### DIFF
--- a/src/main/ank/2.2-limits-and-colimits.md
+++ b/src/main/ank/2.2-limits-and-colimits.md
@@ -87,6 +87,13 @@ fun `p'`() = 0 toT 0
 ```
 ................
 ```Haskell
+p' = p . h
+```
+```kotlin
+val `p'` = p compose h
+```
+................
+```Haskell
 h () = 0
 ```
 ```kotlin:ank:plaground
@@ -114,10 +121,10 @@ val r: (D) -> B
 ```
 ................
 ```Haskell
-g . q = f . q
+g . q = f . p
 ```
 ```kotlin
-g compose q == f compose q
+g compose q == f compose p
 ```
 ................
 ```Haskell
@@ -125,57 +132,6 @@ f x = 1.23
 ```
 ```kotlin
 val f: (A) -> Double = { _: A -> 1.23 }
-```
-................
-```Haskell
-twice f x = f (f x)
-```
-```kotlin
-fun <A> twice() = { f: (A) -> A, x: A -> f(f(x)) }
-```
-................
-```Haskell
-f       :: t0
-x       :: t1
-f x     :: t2
-f (f x) :: t3
-```
-```kotlin
-val f        : t0
-val x        : t1
-val `(f x)`  : t2
-val `f (f x)`: t3
-```
-................
-```Haskell
-twice :: t0 -> t1 -> t3
-```
-```kotlin
-val twice: (t0) -> (t1) -> t3
-```
-................
-```Haskell
-t0 = t1 -> t2 -- because f is applied to x
-t0 = t2 -> t3 -- because f is applied to (f x)
-```
-```kotlin
-typealias t0 = t1 -> t2 // because f is applied to x
-typealias t0 = t2 -> t3 // because f is applied to (f x)
-```
-................
-```Haskell
-t1 = t2 = t3 = Int
-twice :: (Int -> Int) -> Int -> Int
-```
-```kotlin
-fun twice(): ((Int) -> Int, Int) -> Int
-```
-................
-```Haskell
-twice :: (t -> t) -> t -> t
-```
-```kotlin
-fun <A> twice(): ((A) -> A, A) -> A
 ```
 ................
 ```Haskell


### PR DESCRIPTION
### :checkered_flag: 

All the checks for `2.2` are OK with this PR.

### :memo:

* Add a missing Haskell snippet and its translation.
* Fix one Haskell snippet and its translation.
* Remove some snippets. See reasons in [this closed issue](https://github.com/hmemcpy/milewski-ctfp-pdf/issues/206). I feel your pain... It will be avoided with the use of the files in `drafts` directory for the next contributions.