### PR TITLE
Add the possibility of downloading partial PDF file from artifacts menu

### DIFF
--- a/.github/workflows/control-tasks.yml
+++ b/.github/workflows/control-tasks.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Download repository for Kotlin Edition book
-      run: git clone --single-branch --branch kotlin-edition https://github.com/rachelcarmena/milewski-ctfp-pdf.git
+      run: git clone --single-branch --branch wip/kotlin-edition https://github.com/arrow-kt/milewski-ctfp-pdf.git
     - name: Extract Haskell and Kotlin snippets
       run: /bin/bash scripts/extract-snippets-for-book.sh
     - name: Build Kotling Edition
@@ -41,3 +41,9 @@ jobs:
         echo -e "\tFAILURE = PDF file in 'milewski-ctfp-pdf/src' directory"
         echo "PDF files:"
         find ./milewski-ctfp-pdf -name "*.pdf"
+        mkdir pdf-files
+        mv `find ./milewski-ctfp-pdf -name "*.pdf"` pdf-files
+    - uses: actions/upload-artifact@master
+      with:
+        name: partial-book
+        path: pdf-files


### PR DESCRIPTION
Add a few lines to GitHub Actions configuration file to be able to download the partial PDF from **artifacts** menu:

![Screenshot from 2019-09-05 20-53-06](https://user-images.githubusercontent.com/22792183/64370716-4ca5ab00-d01f-11e9-8460-931feff4b523.png)

See [the example with this branch](https://github.com/arrow-kt/Category-Theory-for-Programmers.kt/runs/213453608)

**Note**: the generation of the book stops when finding a missing snippet in Kotlin. Please, take into account that section `1.7` is not right in this branch (pending merge) so some snippets for _Functors_ chapter are not in the right place.