### PR TITLE
Add script to check Kotlin snippets style

### DIFF
--- a/.github/workflows/control-tasks.yml
+++ b/.github/workflows/control-tasks.yml
@@ -13,6 +13,8 @@ jobs:
       run: /bin/bash scripts/extract-snippets-for-book.sh
     - name: Compare Haskell snippets
       run: /bin/bash scripts/compare-haskell-snippets.sh
+    - name: Check Kotlin snippets style
+      run: /bin/bash scripts/check-kotlin-snippets-style.sh
 
   kotlin-edition:
 
@@ -24,7 +26,7 @@ jobs:
       run: git clone --single-branch --branch kotlin-edition https://github.com/rachelcarmena/milewski-ctfp-pdf.git
     - name: Extract Haskell and Kotlin snippets
       run: /bin/bash scripts/extract-snippets-for-book.sh
-    - name: Build Kotling Edition
+    - name: Build Kotlin Edition
       run: |
         cd milewski-ctfp-pdf
         export NIX_CURL_FLAGS=-sS

--- a/scripts/check-kotlin-snippets-style.sh
+++ b/scripts/check-kotlin-snippets-style.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+function showBanner()
+{
+    echo ""
+    echo "    ,,,,,         /\#/\       -  _ ,  -     -  _ ,  -   "
+    echo "   /(o o)\       /(o o)\     -  (o)o)  -   -  (o)o)  -  "
+    echo "ooO--(_)--Ooo-ooO--(_)--Ooo--ooO'(_)--Ooo--ooO'(_)--Ooo-"
+    echo ""
+    echo -e "Checking the style of Kotlin snippets for Category Theory for Programmers\n"
+}
+
+function nonEmptySnippets()
+{
+    SNIPPET=$(basename $snippet)
+    SIZE=$(cat $snippet | sed -e "s/\s//g" -e /^$/d | wc -c)
+    if [ $SIZE -eq 0 ]
+    then
+        echo -e "\n\t  $SNIPPET\n" >> /tmp/kotlin-edition-$SECTION.log
+    fi
+}
+
+function linesLength()
+{
+    SNIPPET=$(basename $snippet)
+    while read -r line; do
+        LENGTH=$(echo "$line" | wc -c)
+        if [ $LENGTH -gt 64 ]
+        then
+            echo -e "\t\t[LENGTH: $LENGTH]  $line" >> /tmp/kotlin-edition-$SNIPPET.log
+        fi
+    done < $snippet
+    if [ -f /tmp/kotlin-edition-$SNIPPET.log ]
+    then
+        echo -e "\n\t  $SNIPPET\n" >> /tmp/kotlin-edition-$SECTION.log
+        cat /tmp/kotlin-edition-$SNIPPET.log >> /tmp/kotlin-edition-$SECTION.log
+    fi
+}
+
+function check()
+{
+    rm -rf /tmp/kotlin-edition*
+    for directory in ../milewski-ctfp-pdf/src/content/*; do
+        if [ ! -d $directory ]; then
+            continue
+        fi
+        SECTION=$(basename $directory)
+        if [ -d $directory/code/kotlin/ ]; then
+            for snippet in $directory/code/kotlin/**
+            do
+                $1
+            done
+            if [ -f /tmp/kotlin-edition-$SECTION.log ]
+            then
+                echo -e "\n\t-----------------------------------------------------------------------"
+                echo -e "\tSection: $SECTION"
+                echo -e "\t-----------------------------------------------------------------------"
+                cat /tmp/kotlin-edition-$SECTION.log
+            fi
+        fi
+        rm -f /tmp/kotlin-edition-*
+    done
+}
+
+cd $(dirname $0)
+showBanner
+
+echo "* Snippets cannot be empty (maybe there are exceptions) ..."
+check nonEmptySnippets
+
+echo "* Length of lines cannot be greater than 64 ..."
+check linesLength


### PR DESCRIPTION
Two extra checks for Kotlin snippets (commented in #29):
*    **Non empty snippets**: there aren't empty snippets so far, though it can be interesting to check it.
*    **The length of the lines**: it shows all the lines which have a length greater than the text width.

![Screenshot from 2019-09-09 13-58-39](https://user-images.githubusercontent.com/22792183/64529212-aac9db00-d30a-11e9-9d92-525967a7ef04.png)


